### PR TITLE
Corrected hyperlink

### DIFF
--- a/index.md
+++ b/index.md
@@ -57,6 +57,6 @@ e `pytorch`. Para instalar um pacote no colab use o pip. Por exemplo, o código 
 
 ## Projetos Práticos
 
-[Projetos práticos - notebooks python] (https://github.com/deep-ufmg/praticas/tree/master/01-Modulo)
+[Projetos práticos - notebooks python](https://github.com/deep-ufmg/praticas/tree/master/01-Modulo)
 
 


### PR DESCRIPTION
Just deleted the space between the [] and (), so the link will work as an hyperlink.